### PR TITLE
Calendar and Publications

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -31,7 +31,7 @@ Everyone is welcome to join the `ECE 264 Group <https://www.linkedin.com/groups/
 |cam2logo|
 
 .. |cam2logo| image:: https://raw.githubusercontent.com/PurdueCAM2Project/HELPSweb/master/source/images/cam2logo4v2.jpg
-   :width: 100%
+   :width: 75%
 
 These projects form the CAM2 (Continuous Analysis of Many CAMeras) family.	   
 

--- a/source/people.rst
+++ b/source/people.rst
@@ -3,7 +3,7 @@ People and Topics
 |cam2logo|
 
 .. |cam2logo| image:: https://raw.githubusercontent.com/PurdueCAM2Project/HELPSweb/master/source/images/cam2logo4v2.jpg
-   :width: 100%
+   :width: 50%
 
 These projects form the CAM2 (Continuous Analysis of Many CAMeras) family.	   
 

--- a/source/people.rst
+++ b/source/people.rst
@@ -30,6 +30,13 @@ Due to the large number of team members, it is not possible changing
 the regular meeting time. If your schedule does not fit into a
 particular team, you have to move to another team.
 
+.. raw:: html
+
+       <iframe src="https://calendar.google.com/calendar/embed?src=k7h268ji8rhp6u9emai80p13oo%40group.calendar.google.com&ctz=America%2FNew_York&mode=WEEK" style="border:solid 1px #777" width="700" height="600" frameborder="0" scrolling="no"></iframe>
+
+|
+
+
 
 Topics
 ~~~~~~

--- a/source/product.rst
+++ b/source/product.rst
@@ -14,6 +14,12 @@ These papers are protected by copyrights. The copyright owners (such as ACM and 
 .. list-table::
    :widths: 30 10
 
+   * -  Abhinav Goel, Sara Aghajanzadeh, Caleb Tung, Shuo-Han Chen,
+        George K. Thiruvathukal, Yung-Hsiang Lu, **Modular Neural Networks
+        for Low-Power Image Classification on Embedded Devices**, ACM Transactions on
+        Design Automation of Electronic Systems, October 2020.
+     -  `[DOI] <https://doi.org/10.1145/3408062>`__
+
    * - Nicholas John Eliopoulos, Yezhi Shen, Minh Luong Nguyen, Vaastav Arora, Yuxin Zhang, Yung-Hsiang Lu, Guofan Shao, and Keith Woeste, **Rapid Tree Diameter Computation with Terrestrial Stereoscopic Photogrammetry**, Journal of Forestry, Volume 118, Issue 4, July 2020.
      - `[Web] <https://academic.oup.com/jof/advance-article-abstract/doi/10.1093/jofore/fvaa009/5811312>`__
 	 

--- a/source/product.rst
+++ b/source/product.rst
@@ -31,12 +31,12 @@ These papers are protected by copyrights. The copyright owners (such as ACM and 
 
    * - Yung-Hsiang Lu, George K. Thiruvathukal, Ahmed S. Kaseb, Kent Gauen, Damini Rijhwani, Ryan Dailey, Deeptanshu Malik, Yutong Huang, Sarah Aghajanzadeh, Minghao Guo, **See the World through Network Cameras**, IEEE Computer. pages 30-40, Volume 52, Issue 10, October 2019.
      - `[PDF] <https://arxiv.org/pdf/1904.06775>`__
+     
+   * - Zohar Kapach, Andrew Ulmer, Daniel Merrick, Arshad Alikhan, Yung-Hsiang Lu, Anup Mohan, Ahmed S. Kaseb, George K. Thiruvathukal, **Cloud Resource Optimization for Processing Multiple Streams of Visual Data**, IEEE Multimedia Magazine, Pages 31-41, Volume 26, Issue 3, July-September 2019.
+     - `[PDF] <https://arxiv.org/pdf/1901.06347>`__
 
    * - Sergei Alyamkin, Matthew Ardi, Alexander C. Berg, Achille Brighton, Bo Chen, Yiran Chen, Hsin-Pai Cheng, Zichen Fan, Chen Feng, Bo Fu, Kent Gauen, Jongkook Go, Abhinav Goel, Alexander Goncharenko, XuHanh Nguyen, Eunbyung Park, Denis Repin, Liang Shen, Tao Sheng, Fei Sun, David Svitov, George K. Thiruvathukal, Baiwu Zhang, Jingchi Zhang, Xiaopeng Zhang, Shaojie Zhuo, **Low-Power Computer Vision: Status, Challenges, Opportunities**, IEEE Journal on Emerging and Selected Topics in Circuits and Systems, Pages 411-421, Volume 9, Issue 2, June 2019.
      - `[PDF] <https://arxiv.org/pdf/1904.07714>`__
-
-   * - Zohar Kapach, Andrew Ulmer, Daniel Merrick, Arshad Alikhan, Yung-Hsiang Lu, Anup Mohan, Ahmed S. Kaseb, George K. Thiruvathukal, **Cloud Resource Optimization for Processing Multiple Streams of Visual Data**, IEEE Multimedia Magazine, Pages 31-41, Volume 26, Issue 3, July-September 2019.
-     - `[PDF] <https://arxiv.org/pdf/1901.06347>`__
 
    * - Yung-Hsiang Lu, **Low-Power Image Recognition**, Nature Machine Intelligence. Vol 1, Page 199, 2019.
      - `[Web] <https://www.nature.com/articles/s42256-019-0041-4>`__

--- a/source/product.rst
+++ b/source/product.rst
@@ -14,14 +14,14 @@ These papers are protected by copyrights. The copyright owners (such as ACM and 
 .. list-table::
    :widths: 30 10
 
-   * - Nicholas John Eliopoulos, Yezhi Shen, Minh Luong Nguyen, Vaastav Arora, Yuxin Zhang, Yung-Hsiang Lu, Guofan Shao, and Keith Woeste, **Rapid Tree Diameter Computation with Terrestrial Stereoscopic Photogrammetry**, Journal of Forestry.
+   * - Nicholas John Eliopoulos, Yezhi Shen, Minh Luong Nguyen, Vaastav Arora, Yuxin Zhang, Yung-Hsiang Lu, Guofan Shao, and Keith Woeste, **Rapid Tree Diameter Computation with Terrestrial Stereoscopic Photogrammetry**, Journal of Forestry, Volume 118, Issue 4, July 2020.
      - `[Web] <https://academic.oup.com/jof/advance-article-abstract/doi/10.1093/jofore/fvaa009/5811312>`__
 	 
+   * - Xiao Hu, Haobo Wang, Anirudh Vegesana, Somesh Dube, Kaiwen Yu, Gore Kao, Shuo-Han Chen, Yung-Hsiang Lu, George K. Thiruvathukal, Ming Yin, **Crowdsourcing Detection of Sampling Biases in Image Datasets**, International World Wide Web Conference 2020.
+     - `[PDF] <https://ecommons.luc.edu/cgi/viewcontent.cgi?article=1244&context=cs_facpubs>`__
+
    * - Xiao Hu, Haobo Wang, Somesh Dube, Anirudh Vegesana, Kaiwen Yu, Yung-Hsiang Lu, Ming Yin, **Discovering Biases in Image Datasets with the Crown**, Human Computation 2019.
      - `[PDF] <http://mingyin.org/HCOMP-19/BiasDetection_camera.pdf>`__
-	 
-   * - Xiao Hu, Haobo Wang, Anirudh Vegesana, SOmesh Dube, Kaiwen Yu, Gore Kao, Shuo-Han Chen, Yung-Hsiang Lu, George K. Thiruvathukal, Ming Yin, **Crowdsourcing Detection of Sampling Biases in Image Datasets**, International World Wide Web Conference 2020.
-     - `[PDF] <http://camps.aptaracorp.com/ACM_PMS/PMS/ACM/WWW20/72/9380193f-3c7e-11ea-b454-16dda94fa160/OUT/www20-72.pdf>`__
 
    * - Yung-Hsiang Lu, George K. Thiruvathukal, Ahmed S. Kaseb, Kent Gauen, Damini Rijhwani, Ryan Dailey, Deeptanshu Malik, Yutong Huang, Sarah Aghajanzadeh, Minghao Guo, **See the World through Network Cameras**, IEEE Computer. pages 30-40, Volume 52, Issue 10, October 2019.
      - `[PDF] <https://arxiv.org/pdf/1904.06775>`__


### PR DESCRIPTION
Reordered and merged publications from Prof. Lu's website, added embedded google calendar, set recurring events as placeholders for actual team calendar invites.